### PR TITLE
Adiciona Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run install
+      run: npm install
+    - name: Run build 
+      run: npm run build 
+    - name: Run test 
+      run: npm run test 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,21 @@ name: CI
 on: [push]
 
 jobs:
-  build:
-
+  install:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v1
     - name: Run install
       run: npm install
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
     - name: Run build 
       run: npm run build 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
     - name: Run test 
       run: npm run test 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Run test 
-      run: npm run test 
+      run: npm run test-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run install
       run: npm install
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
     - name: Run build 
       run: npm run build 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
     - name: Run test 
       run: npm run test-ci

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test-ci": "CI=true react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Ainda testando o Gitlab CI, que é novo e gratuito pra repositório públicos.

Esse PR pode ser um start inicial pra um pipeline, contém apenas as fases de `install`, `build` e `test`.

Ele fica mais visível em `Actions`, dá pra ter uma ideia melhor [aqui](https://github.com/apdaros/agencia-compromisso-web/actions).
